### PR TITLE
docs: add ES modules note to getting started section

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@ This syntax allows you to perform queries that usually aren't possible in ORMs.
 npm install @andrewitsover/midnight
 ```
 
+**Note:** This library uses ES modules. Make sure your `package.json` includes `"type": "module"`, or use the `.mjs` file extension for your files.
+
 This example will create a ```clouds``` table in a database named ```forest.db``` and then insert and read some rows.
 
 ```js


### PR DESCRIPTION
Fixes #5

Added a note in the "Getting started" section to clarify that users need to configure ES modules support (either by adding `"type": "module"` to package.json or using `.mjs` extension).

This will help beginners avoid the common "Cannot use import statement outside a module" error.